### PR TITLE
Update to Request-Promise 0.3.1 (untested)

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/h0ru5/homematic",
   "dependencies": {
-    "request-promise": "0.0.4",
+    "request-promise": "0.3.1",
     "bluebird": "^2.3.0",
     "xml2js": "^0.4.4"
   },

--- a/src/homematic.coffee
+++ b/src/homematic.coffee
@@ -51,12 +51,14 @@ module.exports.getPrograms = (addr,raw) ->
 
 module.exports.runProgram = (addr,id) ->
 	rq urlOf(addr,'runprogram', {'program_id' : id })
+		.promise()
 
 module.exports.setState = (addr, ise, value) ->
 	rq urlOf(addr,'statechange', {
 		'ise_id' : ise
 		'new_value': value
 								 })
+		.promise()
 
 module.exports.getState = (addr,id) ->
 	rq urlOf(addr,'state', {


### PR DESCRIPTION
Hi @h0ru5 

Out of curiosity I checked your code to see if you are affected by braking changes when upgrading to Request-Promise 0.3.1.

You may be, depending on how your users use the return value of `runProgram` and `setState`. To be save I added the `.promise()` call to ensure full compatibility. You can find the details in the [migration instructions](https://github.com/tyabonil/request-promise#migrating-from-02x-to-03x).

Unfortunately, I was unable to run your tests. But the JavaScript code generated from your CoffeeScript looks good.

Frohes Schaffen!
Nico
