### PR TITLE
fix encoding issues

### DIFF
--- a/src/homematic.coffee
+++ b/src/homematic.coffee
@@ -12,6 +12,7 @@ urlOf = (host,script,vars,method='GET') ->
 				'url' : "http://#{host}/config/xmlapi/#{script}.cgi"
 				'withCredentials' : false
 				'scheme' : 'http' #a bug in browserify?
+				'encoding': 'latin1'
 
 parseXml = (xml) ->
 	xml2js.parseStringAsync xml


### PR DESCRIPTION
the xml api does not set an encoding header. request therefore takes utf8. Therefore umlauts are misrepresented